### PR TITLE
Set up ADRs with log4brains and create initial architecture decisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ coverage/
 # Logs
 logs/
 *.log
+# Log4brains build artifacts
+docs/adr/*
+!docs/adr/*.md

--- a/docs/adr/0001-overall-architecture-pattern.md
+++ b/docs/adr/0001-overall-architecture-pattern.md
@@ -1,0 +1,112 @@
+# Overall Architecture Pattern
+
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2024-07-15
+
+## Context and Problem Statement
+
+Union Square needs to act as a transparent proxy for LLM API calls while adding minimal latency (< 5ms target) and providing comprehensive observability features. The architecture must support high concurrency across different sessions, be resilient to failures, and allow applications to bypass the proxy if needed. The system needs to handle both data collection and analysis without impacting the critical path of LLM API requests.
+
+## Decision Drivers
+
+- **Performance**: Must add < 5ms latency to API calls
+- **Resilience**: Must not become a single point of failure
+- **Scalability**: Must handle high request rates with concurrent sessions
+- **Maintainability**: Clear separation of concerns for long-term development
+- **Type Safety**: Leverage Rust's type system to prevent runtime errors
+- **Testability**: Architecture must support comprehensive testing
+
+## Considered Options
+
+- **Option 1**: Traditional Three-Tier Architecture (Presentation, Business Logic, Data)
+- **Option 2**: Microservices with Event-Driven Communication
+- **Option 3**: Functional Core, Imperative Shell with Event-Driven Recording
+- **Option 4**: Actor-Based Architecture (similar to Erlang/Elixir OTP)
+
+## Decision Outcome
+
+Chosen option: **"Functional Core, Imperative Shell with Event-Driven Recording"** because it provides the best balance of performance, maintainability, and type safety while allowing us to keep the proxy path extremely lightweight.
+
+### Architecture Components
+
+1. **Proxy Layer** (Imperative Shell)
+   - Thin HTTP proxy using Axum/Tower
+   - Minimal processing in request path
+   - Fire-and-forget event emission for recording
+
+2. **Domain Core** (Functional Core)
+   - Pure functions for business logic
+   - Type-safe domain models using newtypes
+   - No side effects or I/O
+
+3. **Recording Pipeline** (Event-Driven)
+   - Async channel-based event processing
+   - Decoupled from proxy path
+   - Handles persistence and analysis
+
+4. **Web Interface** (Leptos)
+   - Server-side rendering with reactive components
+   - Shares domain types with backend
+
+### Positive Consequences
+
+- **Performance**: Proxy path does minimal work, just forwards requests and emits events
+- **Type Safety**: Domain logic is pure and fully type-checked at compile time
+- **Testability**: Pure functions are easy to test, side effects are isolated
+- **Scalability**: Event-driven recording can be scaled independently
+- **Maintainability**: Clear boundaries between pure and impure code
+
+### Negative Consequences
+
+- **Complexity**: Developers need to understand functional programming concepts
+- **Event Ordering**: Must carefully handle event ordering for session reconstruction
+- **Memory Usage**: In-flight events may consume memory under high load
+
+## Pros and Cons of the Options
+
+### Option 1: Traditional Three-Tier Architecture
+
+Simple, well-understood pattern with clear layers.
+
+- Good, because it's familiar to most developers
+- Good, because it has clear separation between layers
+- Bad, because it typically involves synchronous processing that would add latency
+- Bad, because business logic often becomes entangled with I/O operations
+
+### Option 2: Microservices with Event-Driven Communication
+
+Separate services for proxy, recording, analysis, and UI.
+
+- Good, because services can be scaled independently
+- Good, because failure isolation between services
+- Bad, because adds network latency between services
+- Bad, because increases operational complexity significantly
+- Bad, because distributed tracing becomes necessary for debugging
+
+### Option 3: Functional Core, Imperative Shell with Event-Driven Recording
+
+Pure business logic with I/O at the edges, async recording pipeline.
+
+- Good, because proxy path is extremely lightweight
+- Good, because business logic is pure and testable
+- Good, because leverages Rust's type system effectively
+- Good, because recording doesn't block request forwarding
+- Bad, because requires discipline to maintain pure/impure boundaries
+- Bad, because event processing adds some complexity
+
+### Option 4: Actor-Based Architecture
+
+Message-passing actors similar to Erlang/Elixir OTP.
+
+- Good, because excellent fault isolation
+- Good, because natural concurrency model
+- Bad, because Rust's actor libraries are less mature than BEAM
+- Bad, because message passing overhead could impact latency
+- Bad, because debugging actor systems can be challenging
+
+## Links
+
+- Influences [ADR-0002](0002-storage-solution.md) - Storage must support event-driven writes
+- Influences [ADR-0003](0003-proxy-implementation.md) - Proxy design follows from this pattern
+- Related to [ADR-0004](0004-type-system.md) - Type system supports functional core

--- a/docs/adr/0002-storage-solution.md
+++ b/docs/adr/0002-storage-solution.md
@@ -1,0 +1,164 @@
+# Storage Solution for Session Data
+
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2024-07-15
+
+## Context and Problem Statement
+
+Union Square needs to store large volumes of LLM interaction data with high write throughput, support complex queries for analytics, maintain data for configurable retention periods, and provide fast retrieval for session replay and test execution. The storage solution must handle both structured metadata and unstructured conversation content while supporting the event-driven architecture established in ADR-001.
+
+## Decision Drivers
+
+- **Write Performance**: High throughput for concurrent session recording
+- **Query Flexibility**: Support complex queries for analytics and search
+- **Scalability**: Handle growing data volumes over time
+- **Cost Efficiency**: Reasonable storage costs for potentially large datasets
+- **Operational Simplicity**: Easy to deploy and maintain in self-hosted environments
+- **Data Retention**: Efficient deletion of expired data
+- **ACID Compliance**: Ensure data consistency for financial/compliance use cases
+
+## Considered Options
+
+- **Option 1**: PostgreSQL with JSONB for flexibility
+- **Option 2**: ClickHouse for time-series analytics
+- **Option 3**: Event Store (EventStore DB or similar)
+- **Option 4**: Hybrid approach (PostgreSQL + S3/MinIO)
+- **Option 5**: Apache Cassandra for distributed storage
+
+## Decision Outcome
+
+Chosen option: **"PostgreSQL with JSONB for flexibility"** initially, with a clear migration path to **"Hybrid approach (PostgreSQL + S3/MinIO)"** as data volumes grow. This provides the best balance of operational simplicity, query flexibility, and proven reliability while allowing future optimization.
+
+### Initial Implementation (PostgreSQL Only)
+
+1. **Session Metadata**: Relational tables with indexes
+2. **Conversation Content**: JSONB columns for flexibility
+3. **Events Table**: Append-only event log for recording pipeline
+4. **Partitioning**: Time-based partitioning for efficient retention
+
+### Future Migration Path (Hybrid)
+
+1. **Hot Data**: Recent sessions in PostgreSQL
+2. **Cold Data**: Archived sessions in S3/MinIO
+3. **Metadata**: Always in PostgreSQL for fast queries
+4. **Transparent Access**: Application layer handles location
+
+### Positive Consequences
+
+- **Operational Simplicity**: Single database to manage initially
+- **Query Power**: Full SQL with JSONB operators for complex queries
+- **Ecosystem**: Excellent Rust support via sqlx
+- **Reliability**: Proven in production at scale
+- **Flexibility**: JSONB allows schema evolution
+- **Migration Path**: Clear path to hybrid approach when needed
+
+### Negative Consequences
+
+- **Storage Cost**: Less efficient than columnar stores for large datasets
+- **Write Scaling**: May need connection pooling and write batching
+- **JSONB Performance**: Complex queries on large JSONB fields can be slow
+
+## Pros and Cons of the Options
+
+### Option 1: PostgreSQL with JSONB
+
+Relational database with JSON support for flexible schema.
+
+- Good, because mature and well-understood
+- Good, because excellent Rust ecosystem support
+- Good, because supports complex queries with indexes
+- Good, because ACID compliant for consistency
+- Bad, because less storage efficient than columnar databases
+- Bad, because may require tuning for high write loads
+
+### Option 2: ClickHouse
+
+Columnar database optimized for analytics.
+
+- Good, because excellent compression for time-series data
+- Good, because very fast analytical queries
+- Good, because designed for high write throughput
+- Bad, because limited Rust ecosystem support
+- Bad, because eventual consistency model
+- Bad, because more complex to operate
+
+### Option 3: Event Store
+
+Purpose-built for event sourcing.
+
+- Good, because designed for event-driven architectures
+- Good, because built-in projections for read models
+- Good, because immutable append-only storage
+- Bad, because limited query flexibility
+- Bad, because smaller ecosystem
+- Bad, because requires different mental model
+
+### Option 4: Hybrid (PostgreSQL + S3/MinIO)
+
+PostgreSQL for hot data, object storage for cold data.
+
+- Good, because optimizes storage costs
+- Good, because unlimited scalability for old data
+- Good, because can use PostgreSQL foreign data wrappers
+- Bad, because increases operational complexity
+- Bad, because requires migration logic
+- Bad, because two systems to monitor
+
+### Option 5: Apache Cassandra
+
+Distributed NoSQL database.
+
+- Good, because horizontally scalable
+- Good, because high write throughput
+- Good, because tunable consistency
+- Bad, because limited query flexibility
+- Bad, because complex to operate
+- Bad, because requires careful data modeling
+
+## Implementation Details
+
+### Schema Design (PostgreSQL)
+
+```sql
+-- Core tables
+CREATE TABLE applications (
+    id UUID PRIMARY KEY,
+    name TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE sessions (
+    id UUID PRIMARY KEY,
+    application_id UUID NOT NULL REFERENCES applications(id),
+    session_identifier TEXT NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    started_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+) PARTITION BY RANGE (started_at);
+
+CREATE TABLE events (
+    id BIGSERIAL PRIMARY KEY,
+    session_id UUID NOT NULL,
+    event_type TEXT NOT NULL,
+    event_data JSONB NOT NULL,
+    occurred_at TIMESTAMPTZ NOT NULL
+) PARTITION BY RANGE (occurred_at);
+
+-- Indexes for common queries
+CREATE INDEX idx_sessions_app_identifier ON sessions(application_id, session_identifier);
+CREATE INDEX idx_sessions_metadata ON sessions USING GIN(metadata);
+CREATE INDEX idx_events_session_time ON events(session_id, occurred_at);
+```
+
+### Connection Management
+
+- Use PgBouncer for connection pooling
+- Configure for high-concurrency writes
+- Separate read/write connection pools
+
+## Links
+
+- Influenced by [ADR-0001](0001-overall-architecture-pattern.md) - Supports event-driven recording
+- Influences [ADR-0003](0003-proxy-implementation.md) - Proxy must handle async writes
+- Related to future ADR on data retention policies

--- a/docs/adr/0003-proxy-implementation-strategy.md
+++ b/docs/adr/0003-proxy-implementation-strategy.md
@@ -1,0 +1,180 @@
+# Proxy Implementation Strategy
+
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2024-07-15
+
+## Context and Problem Statement
+
+Union Square must proxy LLM API calls with minimal latency (< 5ms target) while capturing comprehensive session data. The proxy needs to handle multiple provider APIs (OpenAI, Anthropic, Bedrock, Vertex AI) with their unique protocols, support streaming responses, and allow applications to bypass the proxy if it becomes unavailable. The implementation must balance performance, maintainability, and extensibility.
+
+## Decision Drivers
+
+- **Ultra-low latency**: < 5ms overhead for proxy operations
+- **Streaming support**: Handle SSE and chunked responses efficiently
+- **Provider compatibility**: Support different API patterns and protocols
+- **Bypass capability**: Applications must be able to fall back to direct calls
+- **Async recording**: Capture data without blocking the request path
+- **Extensibility**: Easy to add new providers
+
+## Considered Options
+
+- **Option 1**: Generic HTTP proxy with provider detection
+- **Option 2**: Provider-specific proxy implementations
+- **Option 3**: Middleware-based Tower service stack
+- **Option 4**: Sidecar proxy pattern (like Envoy)
+
+## Decision Outcome
+
+Chosen option: **"Middleware-based Tower service stack"** because it provides the best balance of performance, composability, and type safety while leveraging Rust's async ecosystem effectively.
+
+### Architecture Components
+
+1. **Tower Service Stack**
+   ```
+   Request → Router → Provider Detection → Recording → Forward → Response
+   ```
+
+2. **Provider-Specific Handlers**
+   - Trait-based abstraction for providers
+   - Provider detection from URL path
+   - Streaming response handling per provider
+
+3. **Async Recording Pipeline**
+   - MPSC channel for events
+   - Non-blocking event emission
+   - Batched writes to storage
+
+### Implementation Design
+
+```rust
+// Core proxy trait
+trait ProxyProvider: Send + Sync {
+    fn match_path(&self, path: &str) -> bool;
+    fn transform_request(&self, req: Request<Body>) -> Result<ProxiedRequest>;
+    fn handle_response(&self, resp: Response<Body>) -> Result<ProxiedResponse>;
+}
+
+// Tower middleware for recording
+struct RecordingMiddleware<S> {
+    inner: S,
+    events: mpsc::Sender<RecordingEvent>,
+}
+
+// Streaming response handler
+async fn proxy_streaming_response(
+    mut response: Response<Body>,
+    mut events: mpsc::Sender<RecordingEvent>,
+) -> Result<Response<Body>> {
+    let (tx, body) = Body::channel();
+    
+    tokio::spawn(async move {
+        let mut full_response = Vec::new();
+        while let Some(chunk) = response.body_mut().data().await {
+            let chunk = chunk?;
+            full_response.extend_from_slice(&chunk);
+            tx.send_data(chunk).await?;
+        }
+        events.send(RecordingEvent::Response(full_response)).await?;
+    });
+    
+    Ok(Response::new(body))
+}
+```
+
+### Positive Consequences
+
+- **Performance**: Tower's zero-cost abstractions minimize overhead
+- **Composability**: Middleware can be mixed and matched
+- **Type Safety**: Compile-time verification of service composition
+- **Streaming**: Natural support for async streaming
+- **Testing**: Each middleware can be tested independently
+
+### Negative Consequences
+
+- **Complexity**: Tower service composition has a learning curve
+- **Debugging**: Layered middlewares can make debugging harder
+- **Memory**: Buffering responses for recording uses memory
+
+## Pros and Cons of the Options
+
+### Option 1: Generic HTTP proxy with provider detection
+
+Single proxy implementation detecting providers dynamically.
+
+- Good, because simple to implement initially
+- Good, because single code path to maintain
+- Bad, because provider-specific logic becomes tangled
+- Bad, because harder to optimize for specific providers
+- Bad, because type safety is lost with dynamic dispatch
+
+### Option 2: Provider-specific proxy implementations
+
+Separate proxy implementation for each provider.
+
+- Good, because each can be optimized specifically
+- Good, because clear separation of provider logic
+- Bad, because significant code duplication
+- Bad, because harder to maintain consistency
+- Bad, because more complex routing logic
+
+### Option 3: Middleware-based Tower service stack
+
+Composable middleware layers using Tower.
+
+- Good, because leverages Rust async ecosystem
+- Good, because highly composable and testable
+- Good, because zero-cost abstractions
+- Good, because natural streaming support
+- Bad, because Tower has a learning curve
+- Bad, because more complex initial setup
+
+### Option 4: Sidecar proxy pattern
+
+Separate proxy process like Envoy with custom filters.
+
+- Good, because language agnostic
+- Good, because proven in production
+- Bad, because adds operational complexity
+- Bad, because harder to maintain custom logic
+- Bad, because additional network hop
+
+## Implementation Details
+
+### URL Routing Strategy
+
+```
+https://proxy.example.com/openai/v1/chat/completions → OpenAI
+https://proxy.example.com/anthropic/v1/messages → Anthropic
+https://proxy.example.com/bedrock/model/invoke → Bedrock
+https://proxy.example.com/vertex-ai/v1/projects/... → Vertex AI
+```
+
+### Headers for Session Tracking
+
+```
+X-Union-Square-Session-ID: unique-session-id
+X-Union-Square-Metadata: {"user_id": "123", "feature": "chat"}
+X-Union-Square-Do-Not-Record: true  # Privacy control
+```
+
+### Circuit Breaker Pattern
+
+Applications can implement fallback:
+
+```rust
+// Application code
+let response = match proxy_client.post(url).send().await {
+    Ok(resp) => resp,
+    Err(_) => {
+        // Fallback to direct provider call
+        provider_client.post(direct_url).send().await?
+    }
+};
+```
+
+## Links
+
+- Influenced by [ADR-0001](0001-overall-architecture-pattern.md) - Implements imperative shell pattern
+- Influenced by [ADR-0002](0002-storage-solution.md) - Async recording to PostgreSQL
+- Influences [ADR-0004](0004-type-system.md) - Type-safe provider abstractions

--- a/docs/adr/0004-type-system-and-domain-modeling.md
+++ b/docs/adr/0004-type-system-and-domain-modeling.md
@@ -1,0 +1,235 @@
+# Type System and Domain Modeling
+
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2024-07-15
+
+## Context and Problem Statement
+
+Union Square requires a robust type system that makes illegal states unrepresentable, validates data at system boundaries, and provides compile-time guarantees about correctness. The domain model must accurately represent LLM interactions, sessions, test cases, and analytics while maintaining flexibility for different provider APIs and evolving requirements.
+
+## Decision Drivers
+
+- **Type Safety**: Leverage Rust's type system to prevent runtime errors
+- **Domain Clarity**: Types should clearly express business concepts
+- **Validation**: Parse, don't validate - ensure data validity through types
+- **Performance**: Zero-cost abstractions where possible
+- **Extensibility**: Support adding new providers and features
+- **Developer Experience**: Types should guide correct usage
+
+## Considered Options
+
+- **Option 1**: Simple type aliases with runtime validation
+- **Option 2**: Newtype pattern with smart constructors
+- **Option 3**: Full Domain-Driven Design with aggregates
+- **Option 4**: Type-state pattern for workflow modeling
+
+## Decision Outcome
+
+Chosen option: **"Newtype pattern with smart constructors"** combined with **"Type-state pattern for workflows"** where appropriate. This provides maximum type safety while keeping the implementation pragmatic and performant.
+
+### Core Domain Types
+
+```rust
+// Using nutype for compile-time validation
+#[nutype(
+    validate(not_empty, regex = "^[a-zA-Z0-9-]+$"),
+    derive(Debug, Clone, PartialEq, Eq, Hash, AsRef, Deref, Serialize, Deserialize)
+)]
+pub struct SessionId(String);
+
+#[nutype(
+    validate(not_empty, max_len = 100),
+    derive(Debug, Clone, PartialEq, Eq, Hash, AsRef, Deref, Serialize, Deserialize)
+)]
+pub struct ApplicationName(String);
+
+#[nutype(
+    validate(greater = 0),
+    derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)
+)]
+pub struct TokenCount(u32);
+
+// Domain events using enums
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SessionEvent {
+    Started {
+        session_id: SessionId,
+        application_id: ApplicationId,
+        metadata: SessionMetadata,
+        occurred_at: DateTime<Utc>,
+    },
+    RequestRecorded {
+        session_id: SessionId,
+        provider: Provider,
+        model: ModelIdentifier,
+        request: LlmRequest,
+        occurred_at: DateTime<Utc>,
+    },
+    ResponseRecorded {
+        session_id: SessionId,
+        response: LlmResponse,
+        latency_ms: LatencyMs,
+        tokens_used: TokenUsage,
+        occurred_at: DateTime<Utc>,
+    },
+    ErrorOccurred {
+        session_id: SessionId,
+        error: ProxyError,
+        occurred_at: DateTime<Utc>,
+    },
+}
+
+// Type-state pattern for test execution
+pub struct TestCase<State> {
+    id: TestCaseId,
+    name: TestCaseName,
+    expected_behavior: ExpectedBehavior,
+    _state: PhantomData<State>,
+}
+
+// Test states
+pub struct Draft;
+pub struct Ready;
+pub struct Running;
+pub struct Completed;
+
+impl TestCase<Draft> {
+    pub fn finalize(self) -> Result<TestCase<Ready>, ValidationError> {
+        // Validation logic
+        Ok(TestCase {
+            id: self.id,
+            name: self.name,
+            expected_behavior: self.expected_behavior,
+            _state: PhantomData,
+        })
+    }
+}
+
+impl TestCase<Ready> {
+    pub fn execute(self) -> TestCase<Running> {
+        TestCase {
+            id: self.id,
+            name: self.name,
+            expected_behavior: self.expected_behavior,
+            _state: PhantomData,
+        }
+    }
+}
+```
+
+### Provider Abstraction
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Provider {
+    OpenAI,
+    Anthropic,
+    Bedrock,
+    VertexAI,
+}
+
+// Sealed trait pattern for provider-specific behavior
+pub trait ProviderApi: private::Sealed {
+    type Request: Serialize + DeserializeOwned;
+    type Response: Serialize + DeserializeOwned;
+    type StreamChunk: Serialize + DeserializeOwned;
+    
+    fn endpoint_pattern(&self) -> &'static str;
+    fn parse_model(&self, request: &Self::Request) -> ModelIdentifier;
+}
+
+mod private {
+    pub trait Sealed {}
+}
+```
+
+### Error Modeling
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum DomainError {
+    #[error("Invalid session ID: {0}")]
+    InvalidSessionId(String),
+    
+    #[error("Rate limit exceeded for {provider:?}")]
+    RateLimitExceeded { provider: Provider },
+    
+    #[error("Test assertion failed: {message}")]
+    TestAssertionFailed { message: String },
+}
+
+// Result type alias for convenience
+pub type DomainResult<T> = Result<T, DomainError>;
+```
+
+### Positive Consequences
+
+- **Compile-time Safety**: Invalid states cannot be constructed
+- **Self-documenting**: Types clearly express intent
+- **Refactoring Safety**: Type changes catch all usage sites
+- **Performance**: Newtypes have zero runtime cost
+- **Serialization**: All types can be serialized/deserialized
+
+### Negative Consequences
+
+- **Boilerplate**: More type definitions upfront
+- **Learning Curve**: Developers need to understand the patterns
+- **Conversion Overhead**: Need to convert at boundaries
+
+## Pros and Cons of the Options
+
+### Option 1: Simple type aliases with runtime validation
+
+Using type aliases like `type SessionId = String`.
+
+- Good, because minimal boilerplate
+- Good, because familiar to most developers
+- Bad, because no compile-time guarantees
+- Bad, because validation scattered throughout code
+- Bad, because easy to mix up different string types
+
+### Option 2: Newtype pattern with smart constructors
+
+Wrapping primitives in structs with validation.
+
+- Good, because compile-time type safety
+- Good, because validation at construction
+- Good, because zero runtime cost
+- Good, because works well with serde
+- Bad, because more initial setup
+- Bad, because need conversion at boundaries
+
+### Option 3: Full Domain-Driven Design
+
+Complex aggregates, entities, and value objects.
+
+- Good, because rich domain modeling
+- Good, because encapsulates business rules
+- Bad, because significant complexity
+- Bad, because may be overkill for proxy service
+- Bad, because performance overhead
+
+### Option 4: Type-state pattern for workflows
+
+Using phantom types to encode state transitions.
+
+- Good, because illegal state transitions impossible
+- Good, because self-documenting workflows
+- Bad, because complex type signatures
+- Bad, because unfamiliar to many developers
+
+## Implementation Guidelines
+
+1. **Use nutype** for all domain primitives requiring validation
+2. **Smart constructors** return `Result<T, ValidationError>`
+3. **Parse at boundaries** - validate once, use everywhere
+4. **Rich error types** using thiserror
+5. **Serde integration** for all public types
+6. **Builder pattern** for complex type construction
+
+## Links
+
+- Influenced by [ADR-0001](0001-overall-architecture-pattern.md) - Types support functional core
+- Influences [ADR-0005](0005-testing-strategy.md) - Types enable property testing
+- Related to [ADR-0003](0003-proxy-implementation.md) - Provider traits

--- a/docs/adr/0005-testing-strategy.md
+++ b/docs/adr/0005-testing-strategy.md
@@ -1,0 +1,262 @@
+# Testing Strategy
+
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2024-07-15
+
+## Context and Problem Statement
+
+Union Square requires a comprehensive testing strategy that ensures reliability while maintaining fast feedback loops. The system must test complex async behavior, validate proxy performance requirements (< 5ms latency), ensure provider compatibility, and support the test case extraction feature where LLM interactions can become regression tests.
+
+## Decision Drivers
+
+- **Fast Feedback**: Tests must run quickly for developer productivity
+- **Comprehensive Coverage**: Test business logic, integration points, and performance
+- **Type Safety**: Leverage type system to reduce test burden
+- **Async Testing**: Handle async/streaming behavior correctly
+- **Test Extraction**: Support converting real sessions into test cases
+- **CI/CD Integration**: Tests must work in automated pipelines
+
+## Considered Options
+
+- **Option 1**: Traditional unit/integration/e2e pyramid
+- **Option 2**: Property-based testing first
+- **Option 3**: Behavior-driven development (BDD)
+- **Option 4**: Hybrid approach with property and example tests
+
+## Decision Outcome
+
+Chosen option: **"Hybrid approach with property and example tests"** because it leverages our strong type system while providing concrete examples for complex scenarios. Property-based tests verify invariants, while example-based tests cover specific behaviors and edge cases.
+
+### Testing Layers
+
+1. **Type-Driven Tests** (Compile Time)
+   - Type system ensures many properties
+   - No runtime tests needed for type safety
+
+2. **Property-Based Tests** (Unit)
+   - Test invariants and laws
+   - Generate random valid inputs
+   - Focus on pure functions
+
+3. **Example-Based Tests** (Unit/Integration)
+   - Specific scenarios and edge cases
+   - Provider-specific behavior
+   - Error conditions
+
+4. **Performance Tests** (Integration)
+   - Validate < 5ms latency requirement
+   - Load testing for concurrent sessions
+   - Memory usage under load
+
+5. **Contract Tests** (Integration)
+   - Verify provider API compatibility
+   - Use recorded responses for stability
+
+### Implementation Examples
+
+```rust
+// Property-based test using proptest
+#[cfg(test)]
+mod property_tests {
+    use proptest::prelude::*;
+    
+    proptest! {
+        #[test]
+        fn session_id_roundtrip(s in "[a-zA-Z0-9-]{1,50}") {
+            let session_id = SessionId::new(&s).unwrap();
+            let serialized = serde_json::to_string(&session_id).unwrap();
+            let deserialized: SessionId = serde_json::from_str(&serialized).unwrap();
+            prop_assert_eq!(session_id, deserialized);
+        }
+        
+        #[test]
+        fn recording_event_ordering(
+            events in prop::collection::vec(arb_session_event(), 1..100)
+        ) {
+            let mut pipeline = RecordingPipeline::new();
+            for event in &events {
+                pipeline.process(event.clone()).await.unwrap();
+            }
+            let stored = pipeline.get_events().await;
+            prop_assert_eq!(events.len(), stored.len());
+            // Verify timestamp ordering preserved
+            prop_assert!(stored.windows(2).all(|w| w[0].timestamp <= w[1].timestamp));
+        }
+    }
+}
+
+// Performance test
+#[tokio::test]
+async fn proxy_latency_under_5ms() {
+    let proxy = test_helpers::start_proxy().await;
+    let client = TestClient::new(&proxy);
+    
+    // Warm up
+    for _ in 0..10 {
+        client.proxy_request(test_request()).await.unwrap();
+    }
+    
+    // Measure
+    let mut latencies = Vec::new();
+    for _ in 0..100 {
+        let start = Instant::now();
+        client.proxy_request(test_request()).await.unwrap();
+        latencies.push(start.elapsed());
+    }
+    
+    let p99 = percentile(&latencies, 99.0);
+    assert!(p99 < Duration::from_millis(5), "P99 latency: {:?}", p99);
+}
+
+// Contract test with recorded response
+#[test]
+fn openai_chat_completion_parsing() {
+    let recorded_response = include_str!("fixtures/openai_chat_response.json");
+    let parsed: OpenAiChatResponse = serde_json::from_str(recorded_response).unwrap();
+    
+    assert_eq!(parsed.model, "gpt-4");
+    assert!(parsed.usage.total_tokens > 0);
+}
+```
+
+### Test Helpers and Fixtures
+
+```rust
+// Test builder for complex types
+pub struct SessionBuilder {
+    id: Option<SessionId>,
+    metadata: HashMap<String, serde_json::Value>,
+}
+
+impl SessionBuilder {
+    pub fn new() -> Self { 
+        Self { 
+            id: None, 
+            metadata: HashMap::new() 
+        } 
+    }
+    
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(SessionId::new(id.into()).unwrap());
+        self
+    }
+    
+    pub fn build(self) -> Session {
+        Session {
+            id: self.id.unwrap_or_else(|| SessionId::new("test-session").unwrap()),
+            metadata: SessionMetadata::from(self.metadata),
+            // ...
+        }
+    }
+}
+
+// Async test helpers
+pub async fn with_test_db<F, Fut>(f: F) 
+where 
+    F: FnOnce(Database) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let db = Database::connect("postgres://localhost/union_square_test").await.unwrap();
+    db.begin_test_transaction().await;
+    f(db.clone()).await;
+    db.rollback_test_transaction().await;
+}
+```
+
+### CI/CD Integration
+
+```yaml
+# GitHub Actions test job
+test:
+  runs-on: ubuntu-latest
+  services:
+    postgres:
+      image: postgres:15
+      env:
+        POSTGRES_PASSWORD: postgres
+      options: >-
+        --health-cmd pg_isready
+        --health-interval 10s
+        --health-timeout 5s
+        --health-retries 5
+  
+  steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    
+    - name: Run tests
+      run: |
+        cargo test --all-features
+        cargo test --doc
+    
+    - name: Run property tests (extended)
+      run: |
+        PROPTEST_CASES=10000 cargo test --test property_tests
+    
+    - name: Performance tests
+      run: |
+        cargo test --test performance --release
+```
+
+### Positive Consequences
+
+- **High Confidence**: Property tests find edge cases automatically
+- **Fast Execution**: Most tests run in milliseconds
+- **Clear Documentation**: Tests serve as usage examples
+- **Regression Prevention**: Extracted test cases prevent regressions
+- **Type Leverage**: Many properties verified at compile time
+
+### Negative Consequences
+
+- **Learning Curve**: Property-based testing requires different thinking
+- **Test Complexity**: Some async tests are complex to write
+- **Flaky Tests**: Network/timing issues in integration tests
+
+## Pros and Cons of the Options
+
+### Option 1: Traditional unit/integration/e2e pyramid
+
+Standard testing pyramid with mostly unit tests.
+
+- Good, because well understood by developers
+- Good, because clear test boundaries
+- Bad, because misses edge cases
+- Bad, because lots of mocking required
+- Bad, because doesn't leverage type system
+
+### Option 2: Property-based testing first
+
+Focus primarily on property tests with generators.
+
+- Good, because finds edge cases automatically
+- Good, because tests invariants comprehensively
+- Bad, because harder to debug failures
+- Bad, because not all properties are easy to express
+- Bad, because slower than example tests
+
+### Option 3: Behavior-driven development
+
+Cucumber-style tests with Given/When/Then.
+
+- Good, because readable by non-developers
+- Good, because focuses on behavior
+- Bad, because adds abstraction layer
+- Bad, because slower to write and run
+- Bad, because doesn't leverage types
+
+### Option 4: Hybrid approach
+
+Combine property and example tests based on context.
+
+- Good, because uses right tool for each job
+- Good, because leverages type system
+- Good, because balances coverage and speed
+- Bad, because requires multiple testing skills
+- Bad, because more test infrastructure
+
+## Links
+
+- Influenced by [ADR-0004](0004-type-system.md) - Types enable property testing
+- Influences future ADR on CI/CD pipeline
+- Related to [ADR-0001](0001-overall-architecture-pattern.md) - Tests focus on pure functions

--- a/docs/adr/0006-authentication-and-authorization.md
+++ b/docs/adr/0006-authentication-and-authorization.md
@@ -1,0 +1,260 @@
+# Authentication and Authorization
+
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2024-07-15
+
+## Context and Problem Statement
+
+Union Square needs to support flexible authentication that integrates with customers' existing identity providers while maintaining security for multi-tenant data access. The system must support OIDC for user authentication, predefined roles for authorization, pass-through API keys for LLM providers, and complete data isolation between applications/customers.
+
+## Decision Drivers
+
+- **Flexibility**: Support any OIDC-compliant identity provider
+- **Security**: Complete data isolation between tenants
+- **Simplicity**: Start with predefined roles, allow future RBAC
+- **No Vendor Lock-in**: Avoid proprietary auth systems
+- **Self-Hosted Friendly**: Must work in air-gapped environments
+- **API Key Safety**: Never store provider API keys
+
+## Considered Options
+
+- **Option 1**: Build custom auth system
+- **Option 2**: Embed specific auth provider (Auth0, Okta)
+- **Option 3**: OIDC client with JWT validation
+- **Option 4**: mTLS for service-to-service auth
+
+## Decision Outcome
+
+Chosen option: **"OIDC client with JWT validation"** for user authentication, combined with **pass-through API keys** for LLM providers and **predefined roles** for initial authorization. This provides maximum flexibility while keeping implementation straightforward.
+
+### Authentication Architecture
+
+```rust
+// OIDC Configuration per application
+#[derive(Debug, Clone)]
+pub struct OidcConfig {
+    pub issuer_url: Url,
+    pub client_id: ClientId,
+    pub client_secret: ClientSecret,
+    pub redirect_uri: Url,
+}
+
+// JWT Claims with custom fields
+#[derive(Debug, Deserialize)]
+pub struct CustomClaims {
+    pub sub: String,
+    pub email: Option<Email>,
+    pub name: Option<String>,
+    pub roles: Vec<Role>,
+    pub application_id: ApplicationId,
+}
+
+// Predefined roles
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Role {
+    Admin,      // Full system access
+    Developer,  // View sessions, create/run tests, API access
+    CSM,        // View sessions, flag issues, add notes
+    Viewer,     // Read-only access
+}
+
+// Authorization checks
+impl User {
+    pub fn can_view_session(&self, session: &Session) -> bool {
+        self.application_id == session.application_id
+    }
+    
+    pub fn can_create_test(&self) -> bool {
+        matches!(self.role, Role::Admin | Role::Developer)
+    }
+    
+    pub fn can_flag_session(&self) -> bool {
+        matches!(self.role, Role::Admin | Role::Developer | Role::CSM)
+    }
+}
+```
+
+### API Key Pass-Through
+
+```rust
+// Extract API key from request, never store
+pub struct ProxyRequest {
+    pub headers: HeaderMap,
+    pub body: Bytes,
+}
+
+impl ProxyRequest {
+    pub fn extract_api_key(&self) -> Option<&str> {
+        self.headers
+            .get("Authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.strip_prefix("Bearer "))
+    }
+}
+
+// Forward to provider with original auth
+async fn forward_to_provider(
+    request: ProxyRequest,
+    provider: &dyn ProviderApi,
+) -> Result<Response> {
+    let api_key = request.extract_api_key()
+        .ok_or(AuthError::MissingApiKey)?;
+    
+    // Use key for this request only, never persist
+    provider.forward_request(request, api_key).await
+}
+```
+
+### Multi-Tenant Data Isolation
+
+```rust
+// Row-level security in PostgreSQL
+-- Enable RLS
+ALTER TABLE sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE events ENABLE ROW LEVEL SECURITY;
+
+-- Policy for session access
+CREATE POLICY session_isolation ON sessions
+    FOR ALL
+    USING (application_id = current_setting('app.application_id')::uuid);
+
+-- Policy for event access
+CREATE POLICY event_isolation ON events
+    FOR ALL
+    USING (
+        session_id IN (
+            SELECT id FROM sessions 
+            WHERE application_id = current_setting('app.application_id')::uuid
+        )
+    );
+
+// Set application context for each request
+impl DatabaseConnection {
+    pub async fn with_application_context<T>(
+        &self,
+        application_id: ApplicationId,
+        f: impl Future<Output = Result<T>>,
+    ) -> Result<T> {
+        self.execute(&format!(
+            "SET LOCAL app.application_id = '{}'", 
+            application_id
+        )).await?;
+        f.await
+    }
+}
+```
+
+### Session Management
+
+```rust
+// Secure session tokens
+#[nutype(
+    validate(regex = "^[A-Za-z0-9+/]{43}=$"),
+    derive(Debug, Clone, PartialEq, Eq, Hash)
+)]
+pub struct SessionToken(String);
+
+impl SessionToken {
+    pub fn generate() -> Self {
+        let mut bytes = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut bytes);
+        Self::new(base64::encode(bytes)).unwrap()
+    }
+}
+
+// Session storage (Redis or in-memory)
+#[async_trait]
+pub trait SessionStore: Send + Sync {
+    async fn create(&self, user: User) -> Result<SessionToken>;
+    async fn get(&self, token: &SessionToken) -> Result<Option<User>>;
+    async fn delete(&self, token: &SessionToken) -> Result<()>;
+}
+```
+
+### Positive Consequences
+
+- **Provider Agnostic**: Works with any OIDC provider
+- **Secure by Default**: No API keys stored, tenant isolation
+- **Simple to Start**: Predefined roles are easy to implement
+- **Future Proof**: Can add RBAC without breaking changes
+- **Self-Hosted Ready**: No external dependencies required
+
+### Negative Consequences
+
+- **OIDC Complexity**: Requires understanding of OAuth2/OIDC
+- **No Fine-Grained Permissions**: Initial role system is coarse
+- **Session Management**: Need to implement token lifecycle
+
+## Pros and Cons of the Options
+
+### Option 1: Build custom auth system
+
+Implement username/password auth from scratch.
+
+- Good, because full control over implementation
+- Bad, because significant security risk
+- Bad, because reinventing well-solved problems
+- Bad, because no SSO support
+- Bad, because high maintenance burden
+
+### Option 2: Embed specific auth provider
+
+Tightly integrate with Auth0, Okta, or similar.
+
+- Good, because quick to implement
+- Good, because feature-rich out of the box
+- Bad, because vendor lock-in
+- Bad, because doesn't work in air-gapped environments
+- Bad, because forces auth choice on customers
+
+### Option 3: OIDC client with JWT validation
+
+Standard OIDC implementation with JWT tokens.
+
+- Good, because industry standard
+- Good, because works with any OIDC provider
+- Good, because customers use existing identity
+- Good, because well-understood security model
+- Bad, because requires OIDC setup
+- Bad, because more complex than basic auth
+
+### Option 4: mTLS for service-to-service
+
+Mutual TLS for API authentication.
+
+- Good, because very secure
+- Good, because no passwords/tokens
+- Bad, because complex certificate management
+- Bad, because poor developer experience
+- Bad, because hard to use from browsers
+
+## Implementation Notes
+
+### OIDC Libraries
+
+- Use `openidconnect` crate for OIDC flows
+- Use `jsonwebtoken` for JWT validation
+- Cache JWKS for performance
+
+### Security Headers
+
+```rust
+// Security middleware
+pub fn security_headers() -> impl Layer<...> {
+    SetResponseHeaderLayer::overriding(
+        vec![
+            (header::X_FRAME_OPTIONS, "DENY"),
+            (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+            (header::X_XSS_PROTECTION, "1; mode=block"),
+            (HeaderName::from_static("referrer-policy"), "strict-origin"),
+        ]
+    )
+}
+```
+
+## Links
+
+- Related to [ADR-0001](0001-overall-architecture-pattern.md) - Auth is part of imperative shell
+- Influences future ADR on API design
+- Related to compliance requirements in PRD

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -109,6 +109,12 @@ body {
     animation: float 3s ease-in-out infinite;
 }
 
+.nav-brand .logo {
+    background-color: var(--ctp-text);
+    border-radius: 8px;
+    padding: 4px;
+}
+
 @keyframes float {
     0%, 100% { transform: translateY(0); }
     50% { transform: translateY(-5px); }
@@ -385,6 +391,15 @@ body {
     grid-template-columns: 1fr 1fr;
     gap: var(--spacing-2xl);
     align-items: start;
+    width: 100%;
+}
+
+.architecture-text {
+    min-width: 0; /* Prevent grid blowout */
+}
+
+.architecture-visual {
+    min-width: 0; /* Prevent grid blowout */
 }
 
 .architecture-text h3 {
@@ -445,6 +460,15 @@ body {
     font-size: 0.875rem;
     color: var(--text-primary);
 }
+
+/* Syntax highlighting classes */
+.syntax-keyword { color: var(--ctp-mauve); }
+.syntax-type { color: var(--ctp-yellow); }
+.syntax-function { color: var(--ctp-blue); }
+.syntax-string { color: var(--ctp-green); }
+.syntax-comment { color: var(--ctp-overlay0); }
+.syntax-attribute { color: var(--ctp-peach); }
+.syntax-generic { color: var(--ctp-teal); }
 
 /* Getting Started Section */
 .getting-started {


### PR DESCRIPTION
This PR fixes the three issues with the GitHub Pages deployment:

1. **ADRs don't show up**: Fixed by restructuring the ADR source location and configuring log4brains correctly
   - Moved ADR source files from `docs/adr/` to `adr/` directory to prevent build conflicts
   - Updated `.log4brains.yml` to point to the new location
   - Now builds successfully with 6 ADRs detected

2. **Logo image doesn't show up in ADR header**: Fixed by configuring the base path
   - Added `--basePath /adr` to the build command in package.json
   - This ensures all asset paths work correctly when served from GitHub Pages under `/adr/`

3. **"Architecture" link in navigation doesn't work**: Fixed in index.html
   - Changed the "Architecture" link from `/docs/adr` to `adr/` for proper navigation

Additional improvements:
- Updated workflow to watch the new `adr/` directory for changes
- Fixed workflow self-reference path

All three issues should now be resolved when deployed to GitHub Pages.