### PR TITLE
Increase hero logo size on website

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -52,6 +52,10 @@
     /* Typography */
     --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     --font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', Consolas, monospace;
+    
+    /* Component dimensions */
+    --floating-card-size: 350px;
+    --hero-logo-max-size: 300px;
 }
 
 * {
@@ -316,8 +320,8 @@ body {
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
     animation: float 4s ease-in-out infinite;
     position: relative;
-    width: 350px;
-    height: 350px;
+    width: var(--floating-card-size);
+    height: var(--floating-card-size);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -337,8 +341,8 @@ body {
 .hero-logo {
     width: 90%;
     height: 90%;
-    max-width: 300px;
-    max-height: 300px;
+    max-width: var(--hero-logo-max-size);
+    max-height: var(--hero-logo-max-size);
 }
 
 /* Features Section */

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -312,10 +312,15 @@ body {
 .floating-card {
     background-color: var(--bg-surface);
     border-radius: 20px;
-    padding: var(--spacing-2xl);
+    padding: var(--spacing-lg);
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
     animation: float 4s ease-in-out infinite;
     position: relative;
+    width: 350px;
+    height: 350px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .floating-card::before {
@@ -330,8 +335,10 @@ body {
 }
 
 .hero-logo {
-    width: 200px;
-    height: 200px;
+    width: 90%;
+    height: 90%;
+    max-width: 300px;
+    max-height: 300px;
 }
 
 /* Features Section */


### PR DESCRIPTION
## Summary

This PR increases the size of the Union Square logo in the hero section of the GitHub Pages website to better fill the lighter colored floating card container.

## Changes

- Set the floating card container to fixed dimensions (350x350px)
- Changed logo sizing to use 90% of container with max 300x300px
- Adjusted padding to better accommodate the larger logo
- Added flex centering to ensure logo is properly aligned

## Visual Impact

The logo now fills most of the floating card's lighter colored square, making it more prominent and visually appealing on the landing page.