### PR TITLE
Enhance website logo styling and fix text wrapping

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -316,7 +316,7 @@ body {
 .floating-card {
     background-color: var(--bg-surface);
     border-radius: 20px;
-    padding: var(--spacing-lg);
+    padding: 0;
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
     animation: float 4s ease-in-out infinite;
     position: relative;

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -253,6 +253,7 @@ body {
     color: var(--ctp-green);
     font-weight: 600;
     font-family: var(--font-mono);
+    white-space: nowrap;
 }
 
 .hero-quote {

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -114,9 +114,12 @@ body {
 }
 
 .nav-brand .logo {
-    background-color: var(--ctp-text);
+    width: 60px;
+    height: 60px;
+    background-color: var(--bg-surface);
     border-radius: 8px;
     padding: 4px;
+    animation: none;
 }
 
 @keyframes float {


### PR DESCRIPTION
## Summary

This PR enhances the logo styling across the GitHub Pages website and fixes a text wrapping issue.

## Changes

### Main Hero Logo
- Removed padding from `.floating-card` class (was `var(--spacing-lg)`, now `0`)
- Logo now extends to the edge where the background gradient begins
- Maximizes visual impact of the logo in the hero section

### Header Logo
- Increased size by 50% (from 40px to 60px)
- Removed floating animation (`animation: none`)
- Changed background color to match main body logo (`var(--bg-surface)`)

### Text Wrapping Fix
- Added `white-space: nowrap` to `.highlight` class
- Prevents "< 5ms latency" from wrapping awkwardly after the "<" character
- Ensures the entire highlighted text stays together on one line

## Visual Impact

These changes create a more cohesive and professional appearance with larger, more prominent logos and improved text readability.