### PR TITLE
Add gradient background to header logo

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -56,6 +56,12 @@
     /* Component dimensions */
     --floating-card-size: 350px;
     --hero-logo-max-size: 300px;
+    
+    /* Gradient effects */
+    --gradient-blur-size: 8px;
+    --gradient-blur-size-large: 10px;
+    --gradient-inset-negative: -1px;
+    --gradient-inset-negative-large: -2px;
 }
 
 * {
@@ -126,12 +132,12 @@ body {
 .nav-brand .logo::before {
     content: '';
     position: absolute;
-    inset: -1px;
+    inset: var(--gradient-inset-negative);
     background: linear-gradient(135deg, var(--accent-gradient-start), var(--accent-gradient-end));
     border-radius: 8px;
     z-index: -1;
     opacity: 0.5;
-    filter: blur(8px);
+    filter: blur(var(--gradient-blur-size));
 }
 
 @keyframes float {
@@ -346,12 +352,12 @@ body {
 .floating-card::before {
     content: '';
     position: absolute;
-    inset: -2px;
+    inset: var(--gradient-inset-negative-large);
     background: linear-gradient(135deg, var(--accent-gradient-start), var(--accent-gradient-end));
     border-radius: 20px;
     z-index: -1;
     opacity: 0.5;
-    filter: blur(10px);
+    filter: blur(var(--gradient-blur-size-large));
 }
 
 .hero-logo {

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -120,6 +120,18 @@ body {
     border-radius: 8px;
     padding: 4px;
     animation: none;
+    position: relative;
+}
+
+.nav-brand .logo::before {
+    content: '';
+    position: absolute;
+    inset: -1px;
+    background: linear-gradient(135deg, var(--accent-gradient-start), var(--accent-gradient-end));
+    border-radius: 8px;
+    z-index: -1;
+    opacity: 0.5;
+    filter: blur(8px);
 }
 
 @keyframes float {


### PR DESCRIPTION
## Summary
- Added gradient background to header logo to match the hero section logo
- Used `::before` pseudo-element with the same gradient styling
- Ensures consistent visual branding across the site

## Changes
- Added `position: relative` to `.nav-brand .logo` to enable pseudo-element positioning
- Created `.nav-brand .logo::before` with:
  - Linear gradient background using accent colors (blue to mauve)
  - Adjusted blur and inset values for the smaller header size
  - Matching border-radius (8px)

## Visual Result
The header logo now has the same subtle gradient glow effect as the main hero logo, creating a cohesive visual experience.

🤖 Generated with [Claude Code](https://claude.ai/code)