### PR TITLE
Fix header logo gradient visibility

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -122,7 +122,6 @@ body {
 .nav-brand .logo {
     width: 60px;
     height: 60px;
-    background-color: var(--bg-surface);
     border-radius: 8px;
     padding: 4px;
     animation: none;


### PR DESCRIPTION
## Summary
Fixes the header logo gradient not being visible by removing the solid background color that was blocking it.

## Problem
The gradient effect was not visible on the header logo because:
- The gradient is applied to a `::before` pseudo-element with `z-index: -1`
- The `.nav-brand .logo` had a solid `background-color: var(--bg-surface)` 
- This solid background was blocking the gradient from showing through

## Solution
Removed the `background-color` property from `.nav-brand .logo` to allow the gradient background to be visible behind the logo SVG.

## Result
The header logo now displays the same gradient glow effect as intended, matching the hero section logo.

🤖 Generated with [Claude Code](https://claude.ai/code)