### PR TITLE
Fix header logo gradient to match body logo styling

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -128,12 +128,12 @@ body {
 .nav-brand .logo-container::before {
     content: '';
     position: absolute;
-    inset: var(--gradient-inset-negative);
+    inset: var(--gradient-inset-negative-large);
     background: linear-gradient(135deg, var(--accent-gradient-start), var(--accent-gradient-end));
     border-radius: 8px;
     z-index: -1;
     opacity: 0.5;
-    filter: blur(var(--gradient-blur-size));
+    filter: blur(var(--gradient-blur-size-large));
 }
 
 .nav-brand .logo {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Updated header logo gradient/shadow effects to match the body logo for visual consistency
- Both logos now use the same blur size (10px) and inset (-2px) values
- This gives the header logo the same crisp, defined edges as the main body logo

## Changes
- Modified `.nav-brand .logo-container::before` CSS to use `--gradient-blur-size-large` and `--gradient-inset-negative-large` variables
- No other styling changes were needed

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)