### PR TITLE
docs: reinforce importance of checking all issue pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -624,6 +624,20 @@ Key tools for development workflow:
    mcp__github__list_issues with state="open"
    ```
 
+   **🚨 CRITICAL**: GitHub API paginates results! When listing issues:
+   - Start with a reasonable page size (e.g., `perPage=10` or `perPage=20`)
+   - **ALWAYS check ALL pages** until you get an empty result set
+   - Use the Task tool to efficiently check all pages if there are many issues
+   - **DO NOT** assume the first page shows all available issues
+   - A repository may have 100+ issues across many pages
+
+   **Example**: For repositories with many issues, use the Task tool:
+   ```
+   Use Task tool with prompt: "Check ALL pages of open issues for jwilger/union_square
+   using mcp__github__list_issues with perPage=10. Continue checking pages until you
+   get an empty result. Compile a complete list with issue numbers, titles, and priorities."
+   ```
+
 2. **Prioritize and suggest issues** to work on based on:
    - **HIGHEST PRIORITY**: Issues already assigned to the current user, especially if there's an existing branch for that issue
    - **THEN**: Priority levels (CRITICAL > HIGH > MEDIUM > LOW)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -625,7 +625,7 @@ Key tools for development workflow:
    ```
 
    **🚨 CRITICAL**: GitHub API paginates results! When listing issues:
-   - Start with a reasonable page size (e.g., `perPage=10` or `perPage=20`)
+   - Start with a reasonable page size (e.g., `perPage=5` - larger sizes may exceed token limits)
    - **ALWAYS check ALL pages** until you get an empty result set
    - Use the Task tool to efficiently check all pages if there are many issues
    - **DO NOT** assume the first page shows all available issues
@@ -634,7 +634,7 @@ Key tools for development workflow:
    **Example**: For repositories with many issues, use the Task tool:
    ```
    Use Task tool with prompt: "Check ALL pages of open issues for jwilger/union_square
-   using mcp__github__list_issues with perPage=10. Continue checking pages until you
+   using mcp__github__list_issues with perPage=5. Continue checking pages until you
    get an empty result. Compile a complete list with issue numbers, titles, and priorities."
    ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -633,7 +633,7 @@ Key tools for development workflow:
 
    **Example**: For repositories with many issues, use the Task tool:
    ```
-   Use Task tool with prompt: "Check ALL pages of open issues for jwilger/union_square
+   Use Task tool with prompt: "Check ALL pages of open issues for owner/repository
    using mcp__github__list_issues with perPage=5. Continue checking pages until you
    get an empty result. Compile a complete list with issue numbers, titles, and priorities."
    ```


### PR DESCRIPTION
## Summary

This PR updates CLAUDE.md to emphasize the critical importance of checking ALL pages when listing GitHub issues. The documentation now includes:

- A prominent warning about GitHub API pagination
- Specific instructions on how to handle pagination correctly
- An example showing how to use the Task tool for efficient pagination
- Clear guidance that repositories may have 100+ issues across many pages

## Context

When initially checking for available issues, I only looked at the first page (5 issues) and missed that there were actually 89 total open issues across 18 pages. This documentation update ensures this mistake won't happen again.

## Changes

- Added a `🚨 CRITICAL` section about pagination in the GitHub Issues Workflow
- Included practical examples of using the Task tool for checking all pages
- Emphasized that the first page should never be assumed to show all issues