### PR TITLE
chore: update log4brains from 1.0.1 to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "log4brains": "^1.0.1"
+        "log4brains": "^1.1.0"
       },
       "name": "union-square",
       "version": "0.1.0"
@@ -190,10 +190,10 @@
       "engines": {
         "node": ">=6.9.0"
       },
-      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-      "version": "7.27.6"
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "version": "7.28.2"
     },
     "node_modules/@babel/template": {
       "dependencies": {
@@ -238,10 +238,10 @@
       "engines": {
         "node": ">=6.9.0"
       },
-      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-      "version": "7.28.1"
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "version": "7.28.2"
     },
     "node_modules/@colors/colors": {
       "dev": true,
@@ -2335,10 +2335,10 @@
     },
     "node_modules/electron-to-chromium": {
       "dev": true,
-      "integrity": "sha512-vCrDBYjQCAEefWGjlK3EpoSKfKbT10pR4XXPdn65q7snuNOZnthoVpBfZPykmDapOKfoD+MMIPG8ZjKyyc9oHA==",
+      "integrity": "sha512-k4McmnB2091YIsdCgkS0fMVMPOJgxl93ltFzaryXqwip1AaxeDqKCGLxkXODDA5Ab/D+tV5EL5+aTx76RvLRxw==",
       "license": "ISC",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.183.tgz",
-      "version": "1.5.183"
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.190.tgz",
+      "version": "1.5.190"
     },
     "node_modules/elliptic": {
       "dependencies": {
@@ -3860,13 +3860,13 @@
       "engines": {
         "node": ">= 10"
       },
-      "integrity": "sha512-au62yyLyJukhC2P1TYi3uBi/RScGYai69uT72D8a048QH8rRj+yhND3C21GdZHE+6emtsf6Yqemcf//K+EIWDg==",
+      "integrity": "sha512-Y5xNBqoaTooSLkmlg2P0fdbh53gp4MqW7zhvcweGCPUWvWI5BecWRYI8vPlzT8D7OULxsQg2qoRW9EsJlBWasQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">= 0.14.0"
       },
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.7.10.tgz",
-      "version": "7.7.10"
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.7.12.tgz",
+      "version": "7.7.12"
     },
     "node_modules/math-intrinsics": {
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "Union Square - LLM proxy service",
   "devDependencies": {
-    "log4brains": "^1.0.1"
+    "log4brains": "^1.1.0"
   },
   "name": "union-square",
   "private": true,


### PR DESCRIPTION
## Summary
- Updated log4brains from version 1.0.1 to 1.1.0 (latest version)
- Ran `npm update` to update all dependencies to their latest compatible versions

## Changes
- Updated package.json to specify log4brains ^1.1.0
- Updated package-lock.json with the results of `npm update` (4 packages were updated)

🤖 Generated with [Claude Code](https://claude.ai/code)