### PR TITLE
docs: accept ADR-0017 and improve ADR documentation

### DIFF
--- a/adr/0017-chunked-payload-support-for-ring-buffer.md
+++ b/adr/0017-chunked-payload-support-for-ring-buffer.md
@@ -1,6 +1,6 @@
-# Chunked Payload Support for Ring Buffer
+# ADR-0017: Chunked Payload Support for Ring Buffer
 
-- Status: proposed
+- Status: accepted
 - Deciders: John Wilger, Claude
 - Date: 2025-07-15
 

--- a/adr/index.md
+++ b/adr/index.md
@@ -2,11 +2,38 @@
 
 This directory contains the Architecture Decision Records (ADRs) for the Union Square project.
 
-ADRs are a lightweight way to document architectural decisions made throughout the project. They help future developers understand not just what decisions were made, but why they were made and what alternatives were considered.
+## What are ADRs?
 
-## ADR Index
+Architecture Decision Records (ADRs) are a lightweight way to document architectural decisions made throughout the project. They help future developers understand not just *what* decisions were made, but *why* they were made and what alternatives were considered.
 
-<!-- This index will be automatically maintained by log4brains -->
+## Why use ADRs?
+
+- **Knowledge Preservation**: Captures the context and reasoning behind decisions before it's forgotten
+- **Onboarding**: Helps new team members understand the system's evolution
+- **Decision History**: Provides a historical record of architectural choices
+- **Transparency**: Makes the decision-making process visible and reviewable
+- **Prevents Revisiting**: Reduces time spent re-discussing already-made decisions
+
+## ADR Structure
+
+Each ADR follows a consistent template that includes:
+
+1. **Context and Problem Statement**: What situation or challenge prompted this decision?
+2. **Decision Drivers**: Key factors that influenced the decision
+3. **Considered Options**: Alternative approaches that were evaluated
+4. **Decision Outcome**: The chosen solution and rationale
+5. **Consequences**: Both positive and negative impacts of the decision
+6. **Pros and Cons**: Detailed analysis of each considered option
+
+## ADR Lifecycle
+
+ADRs can have the following statuses:
+- **proposed**: The decision is being discussed but not yet agreed upon
+- **accepted**: The decision has been agreed upon and should be followed
+- **deprecated**: The decision is no longer relevant but kept for historical context
+- **superseded**: The decision has been replaced by a newer ADR
+
+## Working with ADRs
 
 To view ADRs in a web interface, run:
 ```bash
@@ -15,5 +42,21 @@ npm run adr:preview
 
 To create a new ADR, run:
 ```bash
-npm run adr new
+npm run adr:new
 ```
+
+## When to Create an ADR
+
+Create an ADR when making decisions about:
+- Technology choices (databases, frameworks, libraries)
+- Architectural patterns and approaches
+- API design and protocols
+- Security strategies
+- Performance optimization approaches
+- Testing strategies
+- Deployment and infrastructure
+- Any decision with long-term implications
+
+## ADR Index
+
+<!-- This index will be automatically maintained by log4brains -->


### PR DESCRIPTION
## Summary
- Accept ADR-0017 (Chunked Payload Support for Ring Buffer)
- Improve ADR index page with comprehensive documentation about the ADR process

## Changes

### ADR-0017 Updates
- Updated status from "proposed" to "accepted"
- Added ADR number prefix to title: "ADR-0017: Chunked Payload Support for Ring Buffer"

### ADR Index Page Improvements
- Added explanation of what ADRs are and their purpose
- Documented ADR lifecycle and statuses (proposed, accepted, deprecated, superseded)
- Provided guidance on when to create ADRs
- Included overview of ADR structure and template sections
- Explained benefits of using ADRs for knowledge preservation and decision transparency

These changes improve the documentation around the ADR process and bring ADR-0017 in line with project conventions.