### PR TITLE
fix: correct ADR dates to match actual commit dates

### DIFF
--- a/adr/0001-overall-architecture-pattern.md
+++ b/adr/0001-overall-architecture-pattern.md
@@ -2,7 +2,7 @@
 
 - Status: accepted
 - Deciders: John Wilger, Technical Architecture Team
-- Date: 2024-07-15
+- Date: 2025-07-14
 
 ## Context and Problem Statement
 

--- a/adr/0002-storage-solution.md
+++ b/adr/0002-storage-solution.md
@@ -2,7 +2,7 @@
 
 - Status: accepted
 - Deciders: John Wilger, Technical Architecture Team
-- Date: 2024-07-15
+- Date: 2025-07-14
 
 ## Context and Problem Statement
 

--- a/adr/0003-proxy-implementation-strategy.md
+++ b/adr/0003-proxy-implementation-strategy.md
@@ -2,7 +2,7 @@
 
 - Status: accepted
 - Deciders: John Wilger, Technical Architecture Team
-- Date: 2024-07-15
+- Date: 2025-07-14
 
 ## Context and Problem Statement
 

--- a/adr/0004-type-system-and-domain-modeling.md
+++ b/adr/0004-type-system-and-domain-modeling.md
@@ -2,7 +2,7 @@
 
 - Status: accepted
 - Deciders: John Wilger, Technical Architecture Team
-- Date: 2024-07-15
+- Date: 2025-07-14
 
 ## Context and Problem Statement
 

--- a/adr/0005-testing-strategy.md
+++ b/adr/0005-testing-strategy.md
@@ -2,7 +2,7 @@
 
 - Status: accepted
 - Deciders: John Wilger, Technical Architecture Team
-- Date: 2024-07-15
+- Date: 2025-07-14
 
 ## Context and Problem Statement
 

--- a/adr/0006-authentication-and-authorization.md
+++ b/adr/0006-authentication-and-authorization.md
@@ -2,7 +2,7 @@
 
 - Status: accepted
 - Deciders: John Wilger, Technical Architecture Team
-- Date: 2024-07-15
+- Date: 2025-07-14
 
 ## Context and Problem Statement
 

--- a/adr/0008-dual-path-architecture.md
+++ b/adr/0008-dual-path-architecture.md
@@ -1,8 +1,8 @@
 # ADR-0008: Dual-path Architecture (Hot Path vs Audit Path)
 
-## Status
-
-Accepted
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2025-07-15
 
 ## Context
 

--- a/adr/0009-ring-buffer-pattern.md
+++ b/adr/0009-ring-buffer-pattern.md
@@ -1,8 +1,8 @@
 # ADR-0009: Ring Buffer Pattern for Event Recording
 
-## Status
-
-Accepted
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2025-07-15
 
 ## Context
 

--- a/adr/0010-tiered-projection-strategy.md
+++ b/adr/0010-tiered-projection-strategy.md
@@ -1,8 +1,8 @@
 # ADR-0010: Tiered Projection Strategy
 
-## Status
-
-Accepted
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2025-07-15
 
 ## Context
 

--- a/adr/0011-provider-abstraction-and-routing.md
+++ b/adr/0011-provider-abstraction-and-routing.md
@@ -1,8 +1,8 @@
 # ADR-0011: Provider Abstraction and Routing
 
-## Status
-
-Accepted
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2025-07-15
 
 ## Context
 

--- a/adr/0012-session-identification-and-metadata.md
+++ b/adr/0012-session-identification-and-metadata.md
@@ -1,8 +1,8 @@
 # ADR-0012: Session Identification and Metadata Strategy
 
-## Status
-
-Accepted
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2025-07-15
 
 ## Context
 

--- a/adr/0013-test-execution-architecture.md
+++ b/adr/0013-test-execution-architecture.md
@@ -1,8 +1,8 @@
 # ADR-0013: Test Execution Architecture
 
-## Status
-
-Accepted
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2025-07-15
 
 ## Context
 

--- a/adr/0014-privacy-and-compliance-architecture.md
+++ b/adr/0014-privacy-and-compliance-architecture.md
@@ -1,8 +1,8 @@
 # ADR-0014: Privacy and Compliance Architecture
 
-## Status
-
-Accepted
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2025-07-15
 
 ## Context
 

--- a/adr/0015-caching-strategy.md
+++ b/adr/0015-caching-strategy.md
@@ -1,8 +1,8 @@
 # ADR-0015: Caching Strategy
 
-## Status
-
-Accepted
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2025-07-15
 
 ## Context
 

--- a/adr/0016-performance-monitoring-and-metrics.md
+++ b/adr/0016-performance-monitoring-and-metrics.md
@@ -1,8 +1,8 @@
 # ADR-0016: Performance Monitoring and Metrics Collection
 
-## Status
-
-Accepted
+- Status: accepted
+- Deciders: John Wilger, Technical Architecture Team
+- Date: 2025-07-15
 
 ## Context
 


### PR DESCRIPTION
## Summary
- Fixed incorrect years in ADRs 0001-0006 (changed from 2024 to 2025)
- Added missing dates to ADRs 0008-0016
- All dates now accurately reflect when the ADRs were actually committed

## Details
- ADRs 0001-0006: corrected from 2024-07-15 to 2025-07-14
- ADRs 0008-0016: added date of 2025-07-15 (when they were committed in PR #93)
- ADRs 0007 and 0017 already had correct dates and were not modified

This ensures the ADR documentation accurately reflects the project timeline.