### PR TITLE
fix: use RELEASE_PLZ_TOKEN to trigger workflows on release PRs

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
@@ -56,5 +56,5 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace GITHUB_TOKEN with RELEASE_PLZ_TOKEN in release-plz workflow to enable CI workflows to run automatically on release PRs

## Problem
When GitHub Actions creates a PR using the default `GITHUB_TOKEN`, GitHub intentionally doesn't trigger other workflows to prevent infinite loops. This meant our release PRs (#117) didn't run CI checks automatically.

## Solution
Use the `RELEASE_PLZ_TOKEN` (Personal Access Token) that has the necessary `repo` and `workflow` permissions to create PRs that trigger CI workflows normally.

## Changes
- Updated `.github/workflows/release-plz.yml` to use `${{ secrets.RELEASE_PLZ_TOKEN }}` instead of `${{ secrets.GITHUB_TOKEN }}` in both jobs

## Testing
- The RELEASE_PLZ_TOKEN has already been created and added to repository secrets
- Future release PRs will now automatically trigger CI workflows
- This change will be validated when the next release PR is created

Closes #130