### PR TITLE
fix(ci): use RELEASE_PLZ_TOKEN in checkout action to trigger workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
@@ -30,7 +31,7 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
@@ -49,6 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
@@ -56,5 +58,5 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

This PR fixes the release-plz workflow failure that occurred after PR #131 was merged. The previous approach of replacing `GITHUB_TOKEN` with `RELEASE_PLZ_TOKEN` in the env section caused the release-plz action to fail because its internal git-config step expects `GITHUB_TOKEN` to be set.

## Solution

This fix uses a different approach: the `RELEASE_PLZ_TOKEN` is now used in the checkout action's `token` parameter. This allows:
- The checkout to use the PAT (Personal Access Token) which can trigger other workflows
- The release-plz action to still have access to `GITHUB_TOKEN` for its internal operations

## Changes
- Added `token: ${{ secrets.RELEASE_PLZ_TOKEN }}` to both checkout steps in the release-plz workflow
- Kept the original `GITHUB_TOKEN` in the env section unchanged

This should properly trigger CI workflows on release-plz PRs while maintaining compatibility with the release-plz action.

Fixes #130