### PR TITLE
fix(ci): use correct secret name RELEASE_PLZ_PAT in workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          token: ${{ secrets.RELEASE_PLZ_PAT }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          token: ${{ secrets.RELEASE_PLZ_PAT }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz


### PR DESCRIPTION
## Summary

This PR fixes the release-plz workflow failure by using the correct secret name. The workflow was looking for `RELEASE_PLZ_TOKEN` but the actual secret is named `RELEASE_PLZ_PAT`.

## Changes
- Updated both checkout steps in the release-plz workflow to use `${{ secrets.RELEASE_PLZ_PAT }}` instead of `${{ secrets.RELEASE_PLZ_TOKEN }}`

This should resolve the "Input required and not supplied: token" error and allow the release-plz workflow to run successfully.

Fixes #130