### PR TITLE
fix(ci): use RELEASE_PLZ_PAT for GITHUB_TOKEN in release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_PAT }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
@@ -58,5 +58,5 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_PAT }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

This PR completes the fix for enabling CI workflows to trigger on release-plz PRs. According to the release-plz documentation, the PAT must be used in both places for proper workflow triggering.

## Changes
- Updated the `GITHUB_TOKEN` environment variable in both release-plz jobs to use `${{ secrets.RELEASE_PLZ_PAT }}`
- This complements the previous fix where we added the PAT to the checkout action

## Why This Is Needed
When release-plz creates PRs and pushes commits, it needs to use a Personal Access Token (PAT) instead of the default `GITHUB_TOKEN` to trigger other workflows. The PAT must be used:
1. In the checkout action's token parameter (already fixed in PR #133)
2. In the GITHUB_TOKEN environment variable (this PR)

This ensures that all git operations performed by release-plz use the PAT with the necessary permissions.

Fixes #130