### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/jwilger/union_square/compare/v0.1.2...v0.2.0) - 2025-07-28
+
+### Added
+
+- complete EventCore integration in production code ([#153](https://github.com/jwilger/union_square/pull/153))
+- implement F-score tracking and analytics (issue #91) ([#140](https://github.com/jwilger/union_square/pull/140))
+- implement core domain types and newtypes ([#137](https://github.com/jwilger/union_square/pull/137))
+
+### Other
+
+- update expert review with EventCore stream-centric understanding ([#152](https://github.com/jwilger/union_square/pull/152))
+- add expert agent coordination section and update CLAUDE.md ([#151](https://github.com/jwilger/union_square/pull/151))
+- comprehensive type-driven design implementation with centralized constants ([#139](https://github.com/jwilger/union_square/pull/139))
+
 ## [0.1.2](https://github.com/jwilger/union_square/compare/v0.1.1...v0.1.2) - 2025-07-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4498,7 +4498,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "union_square"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "union_square"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["John Wilger <john@johnwilger.com>"]
 description = "A proxy/wire-tap service for making LLM calls and recording everything that happens in a session for later analysis and test-case extraction"


### PR DESCRIPTION



## 🤖 New release

* `union_square`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `union_square` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SessionMetadata.application_id in /tmp/.tmpKAviRr/union_square/src/domain/session.rs:81
  field SessionMetadata.environment_id in /tmp/.tmpKAviRr/union_square/src/domain/session.rs:82
  field SessionMetadata.application_id in /tmp/.tmpKAviRr/union_square/src/domain/session.rs:81
  field SessionMetadata.environment_id in /tmp/.tmpKAviRr/union_square/src/domain/session.rs:82

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum union_square::benchmark_types::MaxConnectionsError, previously in file /tmp/.tmp3qqE5C/union_square/src/benchmark_types.rs:59
  enum union_square::error::ApplicationError, previously in file /tmp/.tmp3qqE5C/union_square/src/error.rs:61

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant DomainEvent::VersionFirstSeen 8 -> 11 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:93
  variant DomainEvent::VersionChanged 9 -> 12 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:98
  variant DomainEvent::VersionUsageRecorded 10 -> 13 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:107
  variant DomainEvent::VersionDeactivated 11 -> 14 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:112
  variant DomainEvent::UserCreated 12 -> 17 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:140
  variant DomainEvent::UserActivated 13 -> 18 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:146
  variant DomainEvent::UserDeactivated 14 -> 19 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:150
  variant DomainEvent::VersionFirstSeen 8 -> 11 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:93
  variant DomainEvent::VersionChanged 9 -> 12 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:98
  variant DomainEvent::VersionUsageRecorded 10 -> 13 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:107
  variant DomainEvent::VersionDeactivated 11 -> 14 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:112
  variant DomainEvent::UserCreated 12 -> 17 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:140
  variant DomainEvent::UserActivated 13 -> 18 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:146
  variant DomainEvent::UserDeactivated 14 -> 19 in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:150

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field application_id of variant DomainEvent::SessionStarted in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:25
  field application_id of variant DomainEvent::SessionStarted in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:25

--- failure enum_struct_variant_field_missing: pub enum struct variant's field removed or renamed ---

Description:
A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_field_missing.ron

Failed in:
  field application_name of variant DomainEvent::SessionStarted, previously in file /tmp/.tmp3qqE5C/union_square/src/domain/events.rs:24
  field application_name of variant DomainEvent::SessionStarted, previously in file /tmp/.tmp3qqE5C/union_square/src/domain/events.rs:24

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant DomainEvent:LlmRequestParsingFailed in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:69
  variant DomainEvent:InvalidStateTransition in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:76
  variant DomainEvent:AuditEventProcessingFailed in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:84
  variant DomainEvent:FScoreCalculated in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:119
  variant DomainEvent:ApplicationFScoreCalculated in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:128
  variant DomainEvent:LlmRequestParsingFailed in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:69
  variant DomainEvent:InvalidStateTransition in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:76
  variant DomainEvent:AuditEventProcessingFailed in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:84
  variant DomainEvent:FScoreCalculated in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:119
  variant DomainEvent:ApplicationFScoreCalculated in /tmp/.tmpKAviRr/union_square/src/domain/events.rs:128

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  ApiKey::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:349
  HttpMethod::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:131
  SessionId::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:357
  SlotSize::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:85
  BypassPath::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:207
  HeaderName::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:155
  RequestUri::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:139
  SlotCount::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:111
  BufferSize::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:77
  RequestSizeLimit::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:61
  RequestId::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:319
  HttpStatusCode::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:147
  TargetUrl::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:341
  DataSize::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:93
  ResponseSizeLimit::new_unchecked, previously in file /tmp/.tmp3qqE5C/union_square/src/proxy/types.rs:69

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field application_name of struct SessionMetadata, previously in file /tmp/.tmp3qqE5C/union_square/src/domain/session.rs:46
  field environment of struct SessionMetadata, previously in file /tmp/.tmp3qqE5C/union_square/src/domain/session.rs:47
  field application_name of struct SessionMetadata, previously in file /tmp/.tmp3qqE5C/union_square/src/domain/session.rs:46
  field environment of struct SessionMetadata, previously in file /tmp/.tmp3qqE5C/union_square/src/domain/session.rs:47
  field cost_cents of struct ResponseMetadata, previously in file /tmp/.tmp3qqE5C/union_square/src/domain/llm.rs:87
  field cost_cents of struct ResponseMetadata, previously in file /tmp/.tmp3qqE5C/union_square/src/domain/llm.rs:87
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/jwilger/union_square/compare/v0.1.2...v0.2.0) - 2025-07-28

### Added

- complete EventCore integration in production code ([#153](https://github.com/jwilger/union_square/pull/153))
- implement F-score tracking and analytics (issue #91) ([#140](https://github.com/jwilger/union_square/pull/140))
- implement core domain types and newtypes ([#137](https://github.com/jwilger/union_square/pull/137))

### Other

- update expert review with EventCore stream-centric understanding ([#152](https://github.com/jwilger/union_square/pull/152))
- add expert agent coordination section and update CLAUDE.md ([#151](https://github.com/jwilger/union_square/pull/151))
- comprehensive type-driven design implementation with centralized constants ([#139](https://github.com/jwilger/union_square/pull/139))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).